### PR TITLE
April/banner improvements

### DIFF
--- a/Extensions/Editor Extensions/Banner/README.md
+++ b/Extensions/Editor Extensions/Banner/README.md
@@ -11,4 +11,3 @@ Provides a top-level banner.
 * Banner text
 * CTA link
 * Banner background color
-

--- a/Extensions/Editor Extensions/Banner/config.json
+++ b/Extensions/Editor Extensions/Banner/config.json
@@ -36,7 +36,7 @@
   ],
   "description": "A horizontal banner across the top of the page",
   "options": {
-    "html": "<div class=\"banner\" style=\"background-color: {{extension.color}}\">\n  {{{ extension.text }}}. \n  <a href=\"{{extension.link}}#\">{{{ extension.link_text }}}</a>\n</div>",
+    "html": "<div class=\"banner\" style=\"background-color: {{extension.color}}\">\n  {{{ extension.text }}}. \n  <a href=\"{{extension.link}}\">{{{ extension.link_text }}}</a>\n</div>",
     "css": ".banner {\n  color: white;\n  padding: 10px;\n\tposition: fixed;\n  top: 0px;\n  z-index: 100000000;\n  width: 100%;\n  text-align: center;\n  height: 45px;\n}\n\n.banner a {\n\ttext-decoration: underline;\n  color: white;\n}\n\nbody {\n margin-top: 45px; \n}",
     "apply_js": "var utils = window.optimizely.get('utils');\n\nutils.waitForElement('body').then(function(element){\n  var html = widget.$html;\n\telement.insertAdjacentHTML('afterbegin',html);\n});\n",
     "undo_js": "var extensionHTML = document.querySelector('.banner');\nif(extensionHTML) extensionHTML.remove();"

--- a/Extensions/Editor Extensions/Banner/config.json
+++ b/Extensions/Editor Extensions/Banner/config.json
@@ -36,7 +36,7 @@
   ],
   "description": "A horizontal banner across the top of the page",
   "options": {
-    "html": "<div class=\"banner\" style=\"background-color: {{extension.color}}\">\n  {{{ extension.text }}}. \n  <a href=\"{{extension.link}}\">{{{ extension.link_text }}}</a>\n</div>",
+    "html": "<div class=\"banner\" style=\"background-color: {{extension.color}}\">\n  {{{ extension.text }}} \n  <a href=\"{{extension.link}}\">{{{ extension.link_text }}}</a>\n</div>",
     "css": ".banner {\n  color: white;\n  padding: 10px;\n\tposition: fixed;\n  top: 0px;\n  z-index: 100000000;\n  width: 100%;\n  text-align: center;\n  height: 45px;\n}\n\n.banner a {\n\ttext-decoration: underline;\n  color: white;\n}\n\nbody {\n margin-top: 45px; \n}",
     "apply_js": "var utils = window.optimizely.get('utils');\n\nutils.waitForElement('body').then(function(element){\n  var html = widget.$html;\n\telement.insertAdjacentHTML('afterbegin',html);\n});\n",
     "undo_js": "var extensionHTML = document.querySelector('.banner');\nif(extensionHTML) extensionHTML.remove();"


### PR DESCRIPTION
We just recently implemented the banner (formerly butterbar) on the Academy to announce the upcoming path and certification changes, and I had a few suggested improvements. (I realized I should have put these as two pull requests, as you might not want to accept both).

**Remove hash from URL**: It was appending a hash tag to the end of a URL. I was using an anchor link and it was breaking it. So, it fixes that, as well as just general code clean-up. (e.g. https://www.optimizely.com/academy/#personas#). 

**Remove period**: We wanted to use an exclamation point, and I had to go to the code to remove the hard-coded period. Just some flexibility for users that want to to control this.