### PR TITLE
Fix for exit intent modal blocking clicks

### DIFF
--- a/Extensions/Editor Extensions/Exit Intent Pop-up/extension.css
+++ b/Extensions/Editor Extensions/Exit Intent Pop-up/extension.css
@@ -5,6 +5,15 @@
   width: 100%;
   text-align: center;
 	height: 100% !important;
+  pointer-events: none;
+}
+
+.exit-intent-modal.fade-in {
+  pointer-events: all;
+}
+
+.exit-intent-modal.fade-in.fade-out {
+  pointer-events: none;
 }
 
 body {


### PR DESCRIPTION
The exit intent modal was blocking clicks on the main webpage, even when it was dismissed.

This is because the HTML for the modal was injected on top of the content and when dismissed was just hidden, not completely removed, meaning that clicks elsewhere on the webpage were blocked by the invisible element.

I have fixed this by adding CSS to the overlay to pass click events through it when it is in the .fade-out state, and recapture those click events when it is in the .fade-in state.