### PR TITLE
Hotjar integration - Add option to enable masking of long numbers 

### DIFF
--- a/Integrations/Analytics/HotJar HeatMaps & Recordings/config.json
+++ b/Integrations/Analytics/HotJar HeatMaps & Recordings/config.json
@@ -44,10 +44,28 @@
           }
         ]
       }
+    },
+    {
+      "default_value": "true",
+      "field_type": "dropdown",
+      "name": "mask_long_numbers",
+      "label": "Mask long numbers?",
+      "options": {
+        "choices": [
+          {
+            "value": "true",
+            "label": "Yes"
+          },
+          {
+            "value": "false",
+            "label": "No"
+          }
+        ]
+      }
     }
   ],
   "description": "This integration allows you to see tag heatmaps and recordings with Optimizely data. For more information on how to use this integration, please take a look at this Knowledge Base article: https://help.optimizely.com/Integrate_Optimizely_with_Hotjar",
   "options": {
-    "track_layer_decision": "// We define the HotJar object if this has not been done already\nwindow.hj=window.hj||function(){(hj.q=hj.q||[]).push(arguments)};\n\n// We get the decision in a string\nvar decisionString = window.optimizely.get(\"state\").getDecisionString({\n  campaignId: campaignId,\n  shouldCleanString:true,\n  maxLength:50\n });\n\nif(extension.heatmaps === \"true\") {\n  // If the visitor is in the holdback\n  if(isHoldback === true) {\n    // We trigger the heatmap\n    hj('trigger', extension.javascript_trigger+'_holdback');\n  } else {\n  \t// We trigger the heatmap\n  \thj('trigger', extension.javascript_trigger+'_'+variationId);\n  }\n}\n\nif(extension.recordings === \"true\") {\n  // We tag recordings with experiment info\n  hj('tagRecording', [decisionString]);\n}\n\n\n"
+    "track_layer_decision": "// We define the HotJar object if this has not been done already\nwindow.hj=window.hj||function(){(hj.q=hj.q||[]).push(arguments)};\n\n// We get the decision in a string\nlet decisionString = window.optimizely.get('state').getDecisionString({\n  campaignId: campaignId,\n  shouldCleanString:true,\n  maxLength:50\n});\n\nif (extension.mask_long_numbers === 'true') {\n  // Mask any sequences of 9 or more digits to avoid PII filter from Hotjar\n  const maskIdRegex = /(\\d{3})\\d{3,}(\\d{3})/g;\n  variationId = variationId.replaceAll(maskIdRegex, '$1...$2');\n  decisionString = decisionString.replaceAll(maskIdRegex, '$1...$2');\n}\n\nif (extension.heatmaps === 'true') {\n  // If the visitor is in the holdback\n  if (isHoldback === true) {\n    // We trigger the heatmap\n    hj('trigger', `${extension.javascript_trigger}_holdback`);\n  } else {\n    // We trigger the heatmap\n    hj('trigger', `${extension.javascript_trigger}_${variationId}`);\n  }\n}\n\nif (extension.recordings === 'true') {\n  // We tag recordings with experiment info\n  hj('tagRecording', [decisionString]);\n}\n"
   }
 }

--- a/Integrations/Analytics/HotJar HeatMaps & Recordings/integration.js
+++ b/Integrations/Analytics/HotJar HeatMaps & Recordings/integration.js
@@ -2,11 +2,18 @@
 window.hj=window.hj||function(){(hj.q=hj.q||[]).push(arguments)};
 
 // We get the decision in a string
-const decisionString = window.optimizely.get('state').getDecisionString({
+let decisionString = window.optimizely.get('state').getDecisionString({
   campaignId: campaignId,
   shouldCleanString:true,
   maxLength:50
 });
+
+if (extension.mask_long_numbers === 'true') {
+  // Mask any sequences of 9 or more digits to avoid PII filter from Hotjar
+  const maskIdRegex = /(\d{3})\d{3,}(\d{3})/g;
+  variationId = variationId.replaceAll(maskIdRegex, '$1...$2');
+  decisionString = decisionString.replaceAll(maskIdRegex, '$1...$2');
+}
 
 if (extension.heatmaps === 'true') {
   // If the visitor is in the holdback

--- a/Integrations/Analytics/HotJar HeatMaps & Recordings/integration.js
+++ b/Integrations/Analytics/HotJar HeatMaps & Recordings/integration.js
@@ -2,26 +2,24 @@
 window.hj=window.hj||function(){(hj.q=hj.q||[]).push(arguments)};
 
 // We get the decision in a string
-var decisionString = window.optimizely.get("state").getDecisionString({
+const decisionString = window.optimizely.get('state').getDecisionString({
   campaignId: campaignId,
   shouldCleanString:true,
   maxLength:50
- });
+});
 
-if(extension.heatmaps === "true") {
+if (extension.heatmaps === 'true') {
   // If the visitor is in the holdback
-  if(isHoldback === true) {
+  if (isHoldback === true) {
     // We trigger the heatmap
-    hj('trigger', extension.javascript_trigger+'_holdback');
+    hj('trigger', `${extension.javascript_trigger}_holdback`);
   } else {
     // We trigger the heatmap
-    hj('trigger', extension.javascript_trigger+'_'+variationId);
+    hj('trigger', `${extension.javascript_trigger}_${variationId}`);
   }
 }
 
-if(extension.recordings === "true") {
+if (extension.recordings === 'true') {
   // We tag recordings with experiment info
   hj('tagRecording', [decisionString]);
 }
-
-


### PR DESCRIPTION
Recently the Hotjar integration stopped working because tags were automatically filtered out. See this response from Hotjar support:

> It looks like the experiment tags are getting flagged as possible PII by our system, as you've noticed. Sorry about that!
>
> These tags are getting flagged because they include a string of 9 or more subsequent numbers:
> 
> The purpose of blocking values like this is to prevent organizations from trying to pass long numeric values like social security numbers, credit card numbers, phone numbers, etc., through Events/Tags. Unfortunately, we don't have a way to disable this built-in safeguard. However, I think we can avoid the issue if you're able to modify your Event or your variant ID.
> 
> We mark a string of numbers as "Potentially Personally Identifiable Information (PII)" when we see 9 or more consecutive digits, when it contains an IP address, or when it contains an email address

Therefore, I have added an additional option in the integration that will mask any sequences of 9 or more consecutive digits. It will keep the first three digits and the last three digits and the middle digits (3 or more) will be replaced with three dots.

I have verified with one customer that the recording tags are now successfully showing up in Hotjar.